### PR TITLE
Added BuildConfig to flow when running the project

### DIFF
--- a/$(BaseDir)/Settings/Platforms/Haxe/flow.xml
+++ b/$(BaseDir)/Settings/Platforms/Haxe/flow.xml
@@ -4,7 +4,7 @@
     <version value="1.0">
       <command name="display" value="flow info $(TargetBuild) --$(BuildConfig) --hxml"/>
       <command name="build" value="flow build $(TargetBuild) --$(BuildConfig)"/>
-      <command name="run" value="flow launch $(TargetBuild) --with-files"/>
+      <command name="run" value="flow launch $(TargetBuild) --$(BuildConfig) --with-files"/>
       <command name="clean" value="flow clean $(TargetBuild)"/>
     </version>
   </versions>


### PR DESCRIPTION
This is needed in case there are some files added to the project via flow only in debug build.